### PR TITLE
remove http dependency & used const variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 // Setup basic express server
-var express = require('express');
-var app = express();
-var path = require('path');
-var server = require('http').createServer(app);
-var io = require('socket.io')(server);
-var port = process.env.PORT || 3000;
+const port = process.env.PORT || 3000;
 
-server.listen(port, () => {
-  console.log('Server listening at port %d', port);
+const express = require('express');
+const app = express();
+const server = app.listen(PORT, () => {
+  console.log(`Server listening at port ${port}`);
 });
+const io = require('socket.io')(server);
+
+const path = require('path');
 
 // Routing
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
http was an unnecessary dependency due to the express module already being used and having the ability to perform the same function
renamed variable prefixes from var to const for block scoping and to assure that these variables are not accidently changed